### PR TITLE
Allow region to be specified.  Necessary if your deployment has multiple...

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ See [Snapshot And Restore](http://www.elasticsearch.org/guide/en/elasticsearch/r
 | swift_password                      | Swift password
 | swift_tenant                        | Swift tenant name, only used with keystone auth
 | swift_username                      | Swift username
+| swift_preferred region              | Region to use.  If you do not specify a region, Swift will pick the endpoint of the first region.  If you have multiple regions, the order is not guarenteed.
 | chunk_size                          | Maximum size for individual objects in the snapshot. Defaults to `5gb` as that's the Swift default
 | compress                            | Turns on compression of the snapshot files. Defaults to `false` as it tends to break with Swift
 | max_restore_bytes_per_sec           | Throttles per node restore rate. Defaults to `20mb` per second.

--- a/src/main/java/org/wikimedia/elasticsearch/swift/repositories/SwiftAccountFactory.java
+++ b/src/main/java/org/wikimedia/elasticsearch/swift/repositories/SwiftAccountFactory.java
@@ -4,16 +4,16 @@ import org.javaswift.joss.model.Account;
 
 public class SwiftAccountFactory {
 
-    public static Account createAccount(SwiftService swiftService, String url, String username, String password, String tenantName, String authMethod) {
+    public static Account createAccount(SwiftService swiftService, String url, String username, String password, String tenantName, String authMethod, String preferredRegion) {
         if ("KEYSTONE".equals(authMethod.toUpperCase())) {
-            return swiftService.swiftKeyStone(url, username, password, tenantName);
+            return swiftService.swiftKeyStone(url, username, password, tenantName, preferredRegion);
         }
 
         if ("TEMPAUTH".equals(authMethod.toUpperCase())) {
-            return swiftService.swiftTempAuth(url, username, password);
+            return swiftService.swiftTempAuth(url, username, password, preferredRegion);
         }
 
-        return swiftService.swiftBasic(url, username, password);
+        return swiftService.swiftBasic(url, username, password, preferredRegion);
 
     }
 

--- a/src/main/java/org/wikimedia/elasticsearch/swift/repositories/SwiftRepository.java
+++ b/src/main/java/org/wikimedia/elasticsearch/swift/repositories/SwiftRepository.java
@@ -62,7 +62,8 @@ public class SwiftRepository extends BlobStoreRepository {
         String password = repositorySettings.settings().get("swift_password", "");
         String tenantName = repositorySettings.settings().get("swift_tenantname", "");
         String authMethod = repositorySettings.settings().get("swift_authmethod", "");
-        Account account = SwiftAccountFactory.createAccount(swiftService, url, username, password, tenantName, authMethod);
+        String preferredRegion = repositorySettings.settings().get("swift_preferred_region", null);
+        Account account = SwiftAccountFactory.createAccount(swiftService, url, username, password, tenantName, authMethod, preferredRegion);
 
         blobStore = new SwiftBlobStore(settings, account, container);
 

--- a/src/main/java/org/wikimedia/elasticsearch/swift/repositories/SwiftService.java
+++ b/src/main/java/org/wikimedia/elasticsearch/swift/repositories/SwiftService.java
@@ -36,13 +36,13 @@ public class SwiftService extends AbstractLifecycleComponent<SwiftService> {
      * @param password
      *            The password
      */
-    public synchronized Account swiftBasic(String url, String username, String password) {
+    public synchronized Account swiftBasic(String url, String username, String password, String preferredRegion) {
         if (swiftUser != null) {
             return swiftUser;
         }
 
         try {
-            AccountConfig conf = getStandardConfig(url, username, password, AuthenticationMethod.BASIC);
+            AccountConfig conf = getStandardConfig(url, username, password, AuthenticationMethod.BASIC, preferredRegion);
             swiftUser = new AccountFactory(conf).createAccount();
         } catch (CommandException ce) {
             throw new ElasticsearchIllegalArgumentException("Unable to authenticate to Swift Basic " + url + "/" + username + "/" + password, ce);
@@ -50,13 +50,13 @@ public class SwiftService extends AbstractLifecycleComponent<SwiftService> {
         return swiftUser;
     }
 
-    public synchronized Account swiftKeyStone(String url, String username, String password, String tenantName) {
+    public synchronized Account swiftKeyStone(String url, String username, String password, String tenantName, String preferredRegion) {
         if (swiftUser != null) {
             return swiftUser;
         }
 
         try {
-            AccountConfig conf = getStandardConfig(url, username, password, AuthenticationMethod.KEYSTONE);
+            AccountConfig conf = getStandardConfig(url, username, password, AuthenticationMethod.KEYSTONE, preferredRegion);
             conf.setTenantName(tenantName);
             swiftUser = new AccountFactory(conf).createAccount();
         } catch (CommandException ce) {
@@ -66,13 +66,13 @@ public class SwiftService extends AbstractLifecycleComponent<SwiftService> {
         return swiftUser;
     }
 
-    public synchronized Account swiftTempAuth(String url, String username, String password) {
+    public synchronized Account swiftTempAuth(String url, String username, String password, String preferredRegion) {
         if (swiftUser != null) {
             return swiftUser;
         }
 
         try {
-            AccountConfig conf = getStandardConfig(url, username, password, AuthenticationMethod.TEMPAUTH);
+            AccountConfig conf = getStandardConfig(url, username, password, AuthenticationMethod.TEMPAUTH, preferredRegion);
             swiftUser = new AccountFactory(conf).createAccount();
         } catch (CommandException ce) {
             throw new ElasticsearchIllegalArgumentException("Unable to authenticate to Swift Temp", ce);
@@ -80,7 +80,7 @@ public class SwiftService extends AbstractLifecycleComponent<SwiftService> {
         return swiftUser;
     }
 
-    private AccountConfig getStandardConfig(String url, String username, String password, AuthenticationMethod method) {
+    private AccountConfig getStandardConfig(String url, String username, String password, AuthenticationMethod method, String preferredRegion) {
         AccountConfig conf = new AccountConfig();
         conf.setAuthUrl(url);
         conf.setUsername(username);
@@ -88,6 +88,7 @@ public class SwiftService extends AbstractLifecycleComponent<SwiftService> {
         conf.setAuthenticationMethod(method);
         conf.setAllowContainerCaching(false);
         conf.setAllowCaching(false);
+        conf.setPreferredRegion(preferredRegion);
         return conf;
     }
 


### PR DESCRIPTION
... regions as the region it selects is completely arbitrary.